### PR TITLE
Adds PEP 561 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     author_email=about["__author_email__"],
     url=about["__url__"],
     packages=[package],
-    package_data={"": ["LICENSE"]},
+    package_data={"": ["LICENSE"], package: ["py.typed"]},
     package_dir={"ipware": "ipware"},
     include_package_data=True,
     python_requires=python_requires,


### PR DESCRIPTION
Fixes #2 

This adds a `py.typed` file to the package data, and runs `mypy` against the code base to almost make it clean.  1 typing error remains which I'm unusre how to fix, but it's quite minor.  The typing changes are easily to revert if desired.